### PR TITLE
docs: create docs for all options inside schema.go, update go version to

### DIFF
--- a/cmd/smf/main.go
+++ b/cmd/smf/main.go
@@ -8,12 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type diffFlags struct {
-	outFile       string
-	format        string
-	detectRenames bool
-}
-
 func main() {
 	rootCmd := &cobra.Command{
 		Use:   "smf",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module smf
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/parser/toml/parser.go
+++ b/internal/parser/toml/parser.go
@@ -255,16 +255,26 @@ func convertTable(tt *tomlTable, dialect string) (*core.Table, error) {
 }
 
 func convertTableOptions(to *tomlTableOptions) core.TableOptions {
-	return core.TableOptions{
-		Engine:       to.Engine,
-		Charset:      to.Charset,
-		Collate:      to.Collate,
-		RowFormat:    to.RowFormat,
-		Tablespace:   to.Tablespace,
-		Compression:  to.Compression,
-		Encryption:   to.Encryption,
-		KeyBlockSize: to.KeyBlockSize,
+	opts := core.TableOptions{
+		Tablespace: to.Tablespace,
 	}
+
+	// Route MySQL-family options into the dialect-specific sub-struct.
+	if to.Engine != "" || to.Charset != "" || to.Collate != "" ||
+		to.RowFormat != "" || to.Compression != "" ||
+		to.Encryption != "" || to.KeyBlockSize != 0 {
+		opts.MySQL = &core.MySQLTableOptions{
+			Engine:       to.Engine,
+			Charset:      to.Charset,
+			Collate:      to.Collate,
+			RowFormat:    to.RowFormat,
+			Compression:  to.Compression,
+			Encryption:   to.Encryption,
+			KeyBlockSize: to.KeyBlockSize,
+		}
+	}
+
+	return opts
 }
 
 func convertColumn(tc *tomlColumn, dialect string) (*core.Column, error) {

--- a/internal/parser/toml/parser_test.go
+++ b/internal/parser/toml/parser_test.go
@@ -54,9 +54,10 @@ func TestParseFileTenants(t *testing.T) {
 	require.NotNil(t, tbl)
 
 	assert.Equal(t, "Tenant / account", tbl.Comment)
-	assert.Equal(t, "InnoDB", tbl.Options.Engine)
-	assert.Equal(t, "utf8mb4", tbl.Options.Charset)
-	assert.Equal(t, "utf8mb4_unicode_ci", tbl.Options.Collate)
+	require.NotNil(t, tbl.Options.MySQL)
+	assert.Equal(t, "InnoDB", tbl.Options.MySQL.Engine)
+	assert.Equal(t, "utf8mb4", tbl.Options.MySQL.Charset)
+	assert.Equal(t, "utf8mb4_unicode_ci", tbl.Options.MySQL.Collate)
 
 	// Timestamps enabled — created_at and updated_at injected.
 	require.NotNil(t, tbl.Timestamps)
@@ -1371,14 +1372,15 @@ name = "items"
 	require.NoError(t, err)
 
 	opts := db.Tables[0].Options
-	assert.Equal(t, "InnoDB", opts.Engine)
-	assert.Equal(t, "utf8mb4", opts.Charset)
-	assert.Equal(t, "utf8mb4_general_ci", opts.Collate)
-	assert.Equal(t, "COMPRESSED", opts.RowFormat)
 	assert.Equal(t, "ts1", opts.Tablespace)
-	assert.Equal(t, "zlib", opts.Compression)
-	assert.Equal(t, "Y", opts.Encryption)
-	assert.Equal(t, uint64(8), opts.KeyBlockSize)
+	require.NotNil(t, opts.MySQL)
+	assert.Equal(t, "InnoDB", opts.MySQL.Engine)
+	assert.Equal(t, "utf8mb4", opts.MySQL.Charset)
+	assert.Equal(t, "utf8mb4_general_ci", opts.MySQL.Collate)
+	assert.Equal(t, "COMPRESSED", opts.MySQL.RowFormat)
+	assert.Equal(t, "zlib", opts.MySQL.Compression)
+	assert.Equal(t, "Y", opts.MySQL.Encryption)
+	assert.Equal(t, uint64(8), opts.MySQL.KeyBlockSize)
 }
 
 // ---------------------------------------------------------------------------

--- a/test/data/schema.toml
+++ b/test/data/schema.toml
@@ -17,7 +17,7 @@
 #       to the correct dialect-specific DDL automatically.
 #
 #   2.  Sensible defaults — you only declare what deviates from the norm:
-#         nullable        -> false   (column are NOT NULL by default)
+#         nullable        -> false   (columns are NOT NULL by default)
 #         primary_key     -> false
 #         auto_increment  -> false
 #         unique          -> false
@@ -126,7 +126,7 @@
 #       PostgreSQL      : GENERATED ALWAYS AS (expr) STORED  (no VIRTUAL before v17)
 #       SQLite          : GENERATED ALWAYS AS (expr) [VIRTUAL | STORED]
 #       Oracle          : col AS (expr) [VIRTUAL]
-#       DB2             : GENERATED ALWAYS AS (expr) — always materialised
+#       DB2             : GENERATED ALWAYS AS (expr) — always materialized
 #       Snowflake       : Not supported (use views)
 #       MSSQL / Azure   : AS (expr) [PERSISTED]
 #
@@ -170,7 +170,7 @@ unique = true  # auto-synthesises UNIQUE constraint
 name = "name"
 type = "varchar(255)"
 
-# Enum with safe TOML array — no embedded quotes, no escaping issues.
+# Enum with a TOML array
 [[tables.columns]]
 name = "plan"
 type = "enum"


### PR DESCRIPTION
1.26, move mysql/mariadb op[tions to their tables